### PR TITLE
devices using i2c now compatible with Raspbian Buster

### DIFF
--- a/blocks/rpi_sfun_imu_wrapper.c
+++ b/blocks/rpi_sfun_imu_wrapper.c
@@ -42,9 +42,11 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 #include "L3G.h"
 #include "LSM303.h"
 #endif

--- a/blocks/rpi_sfun_mpu9150_wrapper.c
+++ b/blocks/rpi_sfun_mpu9150_wrapper.c
@@ -42,9 +42,11 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 #include "MPU-9150.h"
 #endif
 /* %%%-SFUNWIZ_wrapper_includes_Changes_END --- EDIT HERE TO _BEGIN */

--- a/res/ert_rpi_2014a_arm_pi2.tmf
+++ b/res/ert_rpi_2014a_arm_pi2.tmf
@@ -305,7 +305,7 @@ ifeq ($(SFCN),0)
 SYSLIBS += 
 endif
 
-LIBS = -lm -lpthread -lrt -lusb-1.0
+LIBS = -lm -lpthread -lrt -lusb-1.0 -li2c
 |>START_PRECOMP_LIBRARIES<|
 ifeq ($(OPT_OPTS),$(DEFAULT_OPT_OPTS))
 ifeq ($(INTEGER_CODE),0)

--- a/res/ert_rpi_2014a_arm_pi3.tmf
+++ b/res/ert_rpi_2014a_arm_pi3.tmf
@@ -305,7 +305,7 @@ ifeq ($(SFCN),0)
 SYSLIBS += 
 endif
 
-LIBS = -lm -lpthread -lrt -lusb-1.0
+LIBS = -lm -lpthread -lrt -lusb-1.0 -li2c
 |>START_PRECOMP_LIBRARIES<|
 ifeq ($(OPT_OPTS),$(DEFAULT_OPT_OPTS))
 ifeq ($(INTEGER_CODE),0)

--- a/res/ert_rpi_2014a_arm_pi4.tmf
+++ b/res/ert_rpi_2014a_arm_pi4.tmf
@@ -305,7 +305,7 @@ ifeq ($(SFCN),0)
 SYSLIBS += 
 endif
 
-LIBS = -lm -lpthread -lrt -lusb-1.0
+LIBS = -lm -lpthread -lrt -lusb-1.0 -li2c
 |>START_PRECOMP_LIBRARIES<|
 ifeq ($(OPT_OPTS),$(DEFAULT_OPT_OPTS))
 ifeq ($(INTEGER_CODE),0)


### PR DESCRIPTION
only tested under Raspbian Buster on Raspberry Pi 4. expected to work on Raspberry Pi 2 and 3 running under Buster, but not with older distros. 